### PR TITLE
fix: correct color order for tip labels and enable to change tip labels

### DIFF
--- a/R/mult-clust.R
+++ b/R/mult-clust.R
@@ -82,13 +82,14 @@ CLUST.Coe <- function(x,
     stats::dist(method = dist_method) %>%
     stats::hclust(method = hclust_method) %>%
     stats::as.dendrogram()
+  order_d <- stats::order.dendrogram(d)
 
   # handle labels (could be shortened)
   dendextend::`labels<-`(d, names(x))
   if (!missing(fac) && !is.null(fac))          # if fac is provided, use it
-    dendextend::`labels<-`(d, as.character(fac_dispatcher(x, fac)))
+    dendextend::labels(d) <- as.character(fac_dispatcher(x, fac))[order_d]
   if (!missing(labels) && !is.null(labels))      # but if labels is provided, overwrite it
-    dendextend::`labels<-`(d, as.character(fac_dispatcher(x, labels)))
+    dendextend::labels(d) <- as.character(fac_dispatcher(x, labels))[order_d]
 
   # # handles abbreviation
   # if (!missing(abbreviate_n)){ # abbreviate if required
@@ -112,7 +113,7 @@ CLUST.Coe <- function(x,
 
   # color labels
   if (!missing(fac) && !is.null(fac)){
-    f <- fac_dispatcher(x, fac)
+    f <- fac_dispatcher(x, fac)[order_d]
     d %<>% dendextend::set("labels_colors",
                            palette(nlevels(f))[f])
   }


### PR DESCRIPTION
The coloring by `fac` argument was incorrect because the order of the factors returned by the `fac_dipatcher` function was different from the order of the tips(leaves) in dendrograms, which has been corrected. Also, the code for changing tip labels by `fac` and/or `labels` arguments was ineffective, which has been corrected.

## background

When I was coloring tip labels by `fac` argument in `CLUST` function, I noticed that the coloring is constant regardless of the topology of dendrograms. As an example, I ran the following code and found that there was a discrepancy between the tip labels and the colors.

```
hearts |> efourier() |> CLUST(fac=~aut) + coord_flip(xlim=c(25,35)) 
```

This may be due to the fact that the following code specifies the return value of `fac_dispatcher` as it is, when it should specify the colors in the **same order as tip labels**.

```
f <- fac_dispatcher(x, fac)
d %<>% dendextend::set("labels_colors",
                       palette(nlevels(f))[f])
```

Also, the following code seems to intend to change labels appropriately when `fac` or `labels` arguments are specified, but to **no effect**. It seems that this needs to be corrected appropriately as well.

```
# handle labels (could be shortened)
dendextend::`labels<-`(d, names(x))
if (!missing(fac) && !is.null(fac))          # if fac is provided, use it
  dendextend::`labels<-`(d, as.character(fac_dispatcher(x, fac)))
if (!missing(labels) && !is.null(labels))      # but if labels is provided, overwrite it
  dendextend::`labels<-`(d, as.character(fac_dispatcher(x, labels)))
```

